### PR TITLE
feat: add return trip option

### DIFF
--- a/src/app/results/ResultsComponent.ts
+++ b/src/app/results/ResultsComponent.ts
@@ -13,15 +13,24 @@ import { FakeApiService, Trip } from '../services/fake-api.service';
 })
 export class ResultsComponent {
   results: Trip[] = [];
+  returnDate: string | null = null;
 
   constructor(private route: ActivatedRoute, private api: FakeApiService) {
     this.route.queryParamMap.subscribe((params) => {
       const from = params.get('from') ?? '';
       const to = params.get('to') ?? '';
       const travelDate = params.get('travelDate') ?? '';
+      const returnDate = params.get('returnDate');
       const passengers = Number(params.get('passengers') ?? '1');
+      this.returnDate = returnDate;
       this.api
-        .searchTrips({ from, to, travelDate, passengers })
+        .searchTrips({
+          from,
+          to,
+          travelDate,
+          returnDate: returnDate || undefined,
+          passengers,
+        })
         .subscribe((res) => (this.results = res));
     });
   }

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -27,6 +27,13 @@
   cursor: pointer;
 }
 
+.return-info {
+  text-align: center;
+  padding: 0.5rem;
+  font-size: 0.9rem;
+  color: #555;
+}
+
 /* List ----------------------------------------------------------*/
 .results-list {
   display: flex;

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -7,6 +7,10 @@
     <button class="nav-btn" aria-label="Trier">☰</button>
   </header>
 
+  <div class="return-info" *ngIf="returnDate">
+    Retour le {{ returnDate }}
+  </div>
+
   <!-- List ------------------------------------------------------->
   <section class="results-list">
     <article class="trip-card" *ngFor="let r of results">

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -56,6 +56,26 @@
       </select>
     </div>
 
+    <!-- Round trip toggle + return date ----------------------------->
+    <div class="inline-row">
+      <label class="form-check-label">
+        <input
+          type="checkbox"
+          name="roundTrip"
+          [(ngModel)]="roundTrip"
+        />
+        Aller-retour
+      </label>
+      <input
+        *ngIf="roundTrip"
+        class="form-control"
+        type="date"
+        name="returnDate"
+        ngModel
+        [required]="roundTrip"
+      />
+    </div>
+
     <div class="error" *ngIf="error">{{ error }}</div>
 
     <!-- Map preview ----------------------------------------------->

--- a/src/app/services/fake-api.service.ts
+++ b/src/app/services/fake-api.service.ts
@@ -15,7 +15,13 @@ export class FakeApiService {
   }
 
   searchTrips(
-    _params: { from: string; to: string; travelDate: string; passengers: number }
+    _params: {
+      from: string;
+      to: string;
+      travelDate: string;
+      returnDate?: string;
+      passengers: number;
+    }
   ): Observable<Trip[]> {
     const trips: Trip[] = [
       { time: '08 h 30', price: 18, route: 'Tunis → Sfax', seats: '6/8 seats' },


### PR DESCRIPTION
## Summary
- allow selecting a return date during search
- show return date on results screen

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform. Please, set "CHROME_BIN" env variable.)*

------
https://chatgpt.com/codex/tasks/task_e_688e9c7ac8e083279525d225baf0db22