### PR TITLE
Add backend API and fix trip model

### DIFF
--- a/backend/LouageExpress.Api/Entities/Trip.cs
+++ b/backend/LouageExpress.Api/Entities/Trip.cs
@@ -1,0 +1,11 @@
+namespace LouageExpress.Api.Entities;
+
+public record Trip(
+    string Id,
+    string Time,
+    int Price,
+    string Route,
+    string Seats,
+    int Duration,
+    double Rating
+);

--- a/backend/LouageExpress.Api/LouageExpress.Api.csproj
+++ b/backend/LouageExpress.Api/LouageExpress.Api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/backend/LouageExpress.Api/Program.cs
+++ b/backend/LouageExpress.Api/Program.cs
@@ -1,0 +1,8 @@
+using LouageExpress.Api.Repositories;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/trips", () => TripRepository.GetAll());
+
+app.Run();

--- a/backend/LouageExpress.Api/Repositories/TripRepository.cs
+++ b/backend/LouageExpress.Api/Repositories/TripRepository.cs
@@ -1,0 +1,15 @@
+using LouageExpress.Api.Entities;
+
+namespace LouageExpress.Api.Repositories;
+
+public static class TripRepository
+{
+    private static readonly List<Trip> Trips = new()
+    {
+        new("1", "08 h 30", 18, "Tunis → Sfax", "6/8 seats", 195, 4.8),
+        new("2", "09 h 00", 19, "Tunis → Sfax", "5/8 seats", 200, 4.5),
+        new("3", "10 h 00", 20, "Tunis → Sfax", "7/8 seats", 210, 4.2)
+    };
+
+    public static IEnumerable<Trip> GetAll() => Trips;
+}

--- a/src/app/results/ResultsComponent.ts
+++ b/src/app/results/ResultsComponent.ts
@@ -1,6 +1,6 @@
 import { Component, CUSTOM_ELEMENTS_SCHEMA, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { TripService, Trip } from '../services/trip.service';
 import { Subscription } from 'rxjs';
 
@@ -18,9 +18,13 @@ export class ResultsComponent implements OnDestroy {
 
   private sub!: Subscription;
 
+  earliestFilter = false;
+  priceFilter = false;
+
   constructor(
     private route: ActivatedRoute,
-    private trips: TripService
+    private trips: TripService,
+    private router: Router
   ) {
     /* Listen to query-string changes ---------------------------------- */
     this.sub = this.route.queryParamMap.subscribe(params => {
@@ -47,6 +51,18 @@ export class ResultsComponent implements OnDestroy {
         })
         .subscribe(trips => (this.results = trips));
     });
+  }
+
+  openTrip(trip: Trip) {
+    this.router.navigate(['/trip', trip.id], { state: { trip } });
+  }
+
+  toggleEarliestFilter() {
+    this.earliestFilter = !this.earliestFilter;
+  }
+
+  togglePriceFilter() {
+    this.priceFilter = !this.priceFilter;
   }
 
   /* Cleanup to avoid memory leak -------------------------------------- */

--- a/src/app/services/trip.service.ts
+++ b/src/app/services/trip.service.ts
@@ -8,6 +8,8 @@ export interface Trip {
   price: number;         // ex. 18
   route: string;         // ex. "Tunis → Sfax"
   seats: string;         // ex. "6/8 seats"
+  duration: number;      // duration in minutes
+  rating: number;        // ex. 4.8
 }
 
 export interface SearchParams {
@@ -38,6 +40,8 @@ export class TripService {
         price,
         route: `${this.placeName(params.fromPlaceId)} → ${this.placeName(params.toPlaceId)}`,
         seats: `${free}/8 seats`,
+        duration: 60 + Math.floor(Math.random() * 180),
+        rating: Number((3 + Math.random() * 2).toFixed(1)),
       };
     });
 


### PR DESCRIPTION
## Summary
- add static .NET 8 API with sample trip data
- extend Trip model with duration and rating fields
- wire results component navigation and filter toggles

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run build` *(fails: Inlining of fonts failed. https://fonts.googleapis.com/css2... returned status code: 403)*
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_688f90b357888327b146534da517b426