### PR TITLE
feat: centralize app-wide styles

### DIFF
--- a/src/app/auth/onboarding/onboarding.component.css
+++ b/src/app/auth/onboarding/onboarding.component.css
@@ -1,9 +1,4 @@
 /* Positionne le bloc auth en bas de la page */
-.onboarding {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
 .auth-bottom {
   margin-top: auto;
   margin-bottom: 24px;
@@ -18,13 +13,6 @@
   flex-direction: column;
   gap: 12px;
   width: 100%;
-}
-.auth-btn {
-  width: 100%;
-  padding: 12px;
-  font-size: 1rem;
-  border-radius: var(--louage-radius, 24px);
-  font-weight: 600;
 }
 /* Onboarding-specific styles */
 

--- a/src/app/auth/onboarding/onboarding.component.html
+++ b/src/app/auth/onboarding/onboarding.component.html
@@ -1,7 +1,7 @@
 <!-- meta viewport – do this once in index.html ----------------->
 <!-- <meta name="viewport" content="width=device-width,initial-scale=1"> -->
 
-<div class="onboarding">
+<div class="onboarding container">
 
   <header class="brand">
     <span class="name">Louage&nbsp;Express</span>
@@ -30,8 +30,8 @@
   <section class="auth-card auth-bottom">
     <h3>Get started</h3>
     <div class="auth-btns">
-      <button routerLink="/signup" class="btn btn-danger auth-btn">Sign Up</button>
-      <button routerLink="/login" class="btn btn-danger auth-btn">Log In</button>
+      <button routerLink="/signup" class="app-btn">Sign Up</button>
+      <button routerLink="/login" class="app-btn">Log In</button>
     </div>
     <div class="divider"><span>or</span></div>
     <div class="d-flex gap-3">

--- a/src/app/profile-settings/profile-settings.component.css
+++ b/src/app/profile-settings/profile-settings.component.css
@@ -1,9 +1,5 @@
 /* PAGE ----------------------------------------------------------*/
-.container-profile-settings {
-  width: 100%;
-  height: 100vh;             
-  display: flex;
-  flex-direction: column;
+.profile-settings {
   align-items: center;
   font-family: system-ui, sans-serif;
 }
@@ -105,20 +101,3 @@
 .switch input:checked + span        { background: var(--louage-red); }
 .switch input:checked + span::before{ transform: translateX(20px); }
 
-/* Log-out button ----------------------------------------------- */
-.logout-btn {
-  width: calc(100% - 24px);
-  max-width: 480px;
-  margin-top: auto;      /* pousse le bouton en bas */
-  margin-bottom: 24px;   /* petit espace bas */
-  margin-left: 12px; 
-  margin-right: 12px; 
-  padding: 12px;
-  border: 1px solid var(--louage-red);
-  color: var(--louage-red);
-  background: var(--louage-white);
-  border-radius: var(--louage-radius);
-  font-size: 15px;
-  cursor: pointer;
-}
-.logout-btn:hover { background: var(--louage-red); color: #fff; }

--- a/src/app/profile-settings/profile-settings.component.html
+++ b/src/app/profile-settings/profile-settings.component.html
@@ -1,4 +1,4 @@
-<div class=".container-profile-settings">
+<div class="container profile-settings">
   <!-- HEADER / TOP 25% ------------------------------------------>
   <div class="header">
     <!-- Flèche retour -->
@@ -65,5 +65,5 @@
   </div>
 
   <!-- LOG-OUT -->
-  <button class="logout-btn" routerLink="/">Déconnexion</button>
+  <button class="app-btn" routerLink="/">Déconnexion</button>
 </div>

--- a/src/app/results/results.component.css
+++ b/src/app/results/results.component.css
@@ -1,9 +1,5 @@
 /* Layout --------------------------------------------------------*/
 .results-screen {
-  min-height: 100vh;
-  background: var(--louage-grey);
-  display: flex;
-  flex-direction: column;
   padding-bottom: 5rem; /* space for filter sheet */
 }
 

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -1,5 +1,5 @@
 <!-- Results screen --------------------------------------------->
-<div class="results-screen">
+<div class="container results-screen">
   <!-- App-bar ---------------------------------------------------->
   <header class="results-header">
     <button

--- a/src/app/search/search.component.css
+++ b/src/app/search/search.component.css
@@ -1,9 +1,5 @@
 /* Layout ---------------------------------------------------------*/
 .search-screen {
-  min-height: 100vh;
-  background: var(--louage-grey);
-  display: flex;
-  flex-direction: column;
   align-items: center;
   padding: 1.25rem 0.75rem 5rem; /* bottom pad for FAB */
 }

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -1,4 +1,4 @@
-<div class="search-screen">
+<div class="container search-screen">
   <header class="search-header">
     <button
       class="btn btn-link link-dark p-0 me-2"
@@ -76,7 +76,7 @@
 
     <div class="error" *ngIf="error">{{ error }}</div>
     <button
-      class="btn btn-danger"
+      class="app-btn"
       type="submit"
       [disabled]="searchForm.invalid || !fromPlace || !toPlace"
     >

--- a/src/app/support-feedback/support-feedback.component.css
+++ b/src/app/support-feedback/support-feedback.component.css
@@ -1,9 +1,3 @@
-.container {
-  padding: 16px;
-  background: var(--louage-grey);
-  min-height: 100vh;
-  position: relative;
-}
 .search {
   width: 100%;
   padding: 8px 12px;
@@ -47,14 +41,6 @@ textarea {
   border: 1px solid var(--louage-border);
   border-radius: var(--louage-radius);
   margin-bottom: 12px;
-}
-.submit-btn {
-  width: 100%;
-  background: var(--louage-red);
-  color: var(--louage-white);
-  border: none;
-  padding: 12px;
-  border-radius: var(--louage-radius);
 }
 .chat-bubble {
   position: fixed;

--- a/src/app/support-feedback/support-feedback.component.html
+++ b/src/app/support-feedback/support-feedback.component.html
@@ -18,7 +18,7 @@
       <span *ngFor="let star of [1,2,3,4,5]" (click)="setRating(star)" [class.active]="star <= rating">★</span>
     </div>
     <textarea placeholder="Laissez un commentaire…"></textarea>
-    <button class="submit-btn">Envoyer</button>
+    <button class="app-btn">Envoyer</button>
   </div>
 
   <button class="chat-bubble">💬</button>

--- a/src/app/trip-detail/trip-detail.component.css
+++ b/src/app/trip-detail/trip-detail.component.css
@@ -1,8 +1,4 @@
 .trip-detail-screen {
-  background: #f5f5f5;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
   align-items: center;
 }
 .hero {
@@ -78,18 +74,5 @@
   gap: 0.25rem;
   font-size: 0.9rem;
 }
-.reserve-btn {
-  width: calc(100% - 24px);
-  max-width: 480px;
-  margin-top: auto;      /* pousse le bouton en bas */
-  margin-bottom: 25px;   /* petit espace bas */
-    margin-left: 12px;   /* petit espace bas */
-  margin-right: 12px;   /* petit espace bas */
-  padding: 12px;
-  border: 1px solid var(--louage-red);
-  color: var(--louage-red);
-  background: var(--louage-white);
-  border-radius: var(--louage-radius);
-  font-size: 15px;
-  cursor: pointer;
-}
+/* Button pushed to bottom via global styles */
+

--- a/src/app/trip-detail/trip-detail.component.html
+++ b/src/app/trip-detail/trip-detail.component.html
@@ -1,4 +1,4 @@
-<div class="trip-detail-screen">
+<div class="container trip-detail-screen">
   <header class="hero">
     <img
       class="hero-img"
@@ -41,5 +41,5 @@
     </div>
   </div>
 
-  <button class="reserve-btn">Réserver</button>
+  <button class="app-btn">Réserver</button>
 </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -33,3 +33,32 @@ small {
   background-color: #b71c1c !important;
   border-color: #b71c1c !important;
 }
+
+.container {
+  min-height: 100vh;
+  padding: 16px;
+  background: var(--louage-grey);
+  display: flex;
+  flex-direction: column;
+}
+
+.app-btn {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid var(--louage-red);
+  background: var(--louage-white);
+  color: var(--louage-red);
+  border-radius: var(--louage-radius);
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.app-btn:hover {
+  background: var(--louage-red);
+  color: var(--louage-white);
+}
+
+.container > .app-btn:last-child {
+  margin-top: auto;
+  margin-bottom: 24px;
+}


### PR DESCRIPTION
## Summary
- add reusable `.container` and `.app-btn` rules to global styles
- refactor feature pages to use shared layout and button classes

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688fc29d0b248327a548d4da939a6494