### PR TITLE
feat: implement basic backend services

### DIFF
--- a/backend/LouageExpress.Api/Entities/Reservation.cs
+++ b/backend/LouageExpress.Api/Entities/Reservation.cs
@@ -1,0 +1,8 @@
+namespace LouageExpress.Api.Entities;
+
+public record Reservation(
+    string Id,
+    string TripId,
+    string UserId,
+    int Seats,
+    DateTime CreatedAt);

--- a/backend/LouageExpress.Api/Entities/User.cs
+++ b/backend/LouageExpress.Api/Entities/User.cs
@@ -1,0 +1,7 @@
+namespace LouageExpress.Api.Entities;
+
+public record User(
+    string Id,
+    string Email,
+    string Password,
+    Dictionary<string, object> Preferences);

--- a/backend/LouageExpress.Api/Program.cs
+++ b/backend/LouageExpress.Api/Program.cs
@@ -1,8 +1,50 @@
+using LouageExpress.Api.Entities;
 using LouageExpress.Api.Repositories;
 
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
+// Trips
 app.MapGet("/trips", () => TripRepository.GetAll());
 
+// Authentication
+app.MapPost("/auth/login", (LoginRequest request) =>
+{
+    var user = UserRepository.GetByEmail(request.Email);
+    if (user is null || user.Password != request.Password)
+    {
+        return Results.Unauthorized();
+    }
+    var token = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
+    return Results.Ok(new { token });
+});
+
+// User profile
+app.MapGet("/users/me", () =>
+{
+    var user = UserRepository.GetCurrent();
+    return Results.Ok(new { email = user.Email, preferences = user.Preferences });
+});
+
+app.MapPut("/users/me/preferences", (Dictionary<string, object> prefs) =>
+{
+    var user = UserRepository.UpdatePreferences(prefs);
+    return Results.Ok(new { email = user.Email, preferences = user.Preferences });
+});
+
+// Reservations
+app.MapPost("/reservations", (ReservationRequest request) =>
+{
+    if (request.Seats < 1 || request.Seats > 8)
+    {
+        return Results.BadRequest(new { message = "Invalid seats" });
+    }
+    var user = UserRepository.GetCurrent();
+    var reservation = ReservationRepository.Add(request.TripId, user.Id, request.Seats);
+    return Results.Ok(new { confirmationId = reservation.Id });
+});
+
 app.Run();
+
+record LoginRequest(string Email, string Password);
+record ReservationRequest(string TripId, int Seats);

--- a/backend/LouageExpress.Api/Repositories/ReservationRepository.cs
+++ b/backend/LouageExpress.Api/Repositories/ReservationRepository.cs
@@ -1,0 +1,24 @@
+using LouageExpress.Api.Entities;
+
+namespace LouageExpress.Api.Repositories;
+
+public static class ReservationRepository
+{
+    private static readonly List<Reservation> Reservations = new();
+
+    public static Reservation Add(string tripId, string userId, int seats)
+    {
+        var reservation = new Reservation(
+            Guid.NewGuid().ToString(),
+            tripId,
+            userId,
+            seats,
+            DateTime.UtcNow
+        );
+
+        Reservations.Add(reservation);
+        return reservation;
+    }
+
+    public static IEnumerable<Reservation> GetAll() => Reservations;
+}

--- a/backend/LouageExpress.Api/Repositories/UserRepository.cs
+++ b/backend/LouageExpress.Api/Repositories/UserRepository.cs
@@ -1,0 +1,27 @@
+using LouageExpress.Api.Entities;
+
+namespace LouageExpress.Api.Repositories;
+
+public static class UserRepository
+{
+    private static readonly User DemoUser = new(
+        "1",
+        "demo@louage-express.tn",
+        "password",
+        new()
+    );
+
+    public static User? GetByEmail(string email) =>
+        email.Equals(DemoUser.Email, StringComparison.OrdinalIgnoreCase) ? DemoUser : null;
+
+    public static User GetCurrent() => DemoUser;
+
+    public static User UpdatePreferences(Dictionary<string, object> prefs)
+    {
+        foreach (var kvp in prefs)
+        {
+            DemoUser.Preferences[kvp.Key] = kvp.Value!;
+        }
+        return DemoUser;
+    }
+}


### PR DESCRIPTION
## Summary
- add user and reservation entities and repositories with in-memory caches
- extend API endpoints for auth, user profile, and reservations

## Testing
- `dotnet build backend/LouageExpress.Api/LouageExpress.Api.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688fc31765e08327a1915ac269e29cd0