### PR TITLE
feat: add swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ ng e2e
 
 Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
 
+## Backend API
+
+The backend API is built with ASP.NET Core. To run it locally, use:
+
+```bash
+dotnet run --project backend/LouageExpress.Api
+```
+
+When the server is running, Swagger UI is available at `http://localhost:5000/swagger` for exploring the available endpoints.
+
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.

--- a/backend/LouageExpress.Api/LouageExpress.Api.csproj
+++ b/backend/LouageExpress.Api/LouageExpress.Api.csproj
@@ -4,4 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
 </Project>

--- a/backend/LouageExpress.Api/Program.cs
+++ b/backend/LouageExpress.Api/Program.cs
@@ -1,8 +1,19 @@
 using LouageExpress.Api.Entities;
 using LouageExpress.Api.Repositories;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "LouageExpress API", Version = "v1" });
+});
+
 var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
 
 // Trips
 app.MapGet("/trips", () => TripRepository.GetAll());


### PR DESCRIPTION
## Summary
- add Swashbuckle package for API docs
- configure Swagger UI in backend API
- document backend API and Swagger endpoint in README

## Testing
- `dotnet restore backend/LouageExpress.Api` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fe0f1a8fc8327a17123100eb0ff21